### PR TITLE
Modify the memory search method

### DIFF
--- a/pkg/memory/memory.go
+++ b/pkg/memory/memory.go
@@ -16,7 +16,7 @@ type Gomem struct {
 	IsWow64       bool
 }
 
-func NewGomem(processId interface{}, desiredAccess *uint32) (*Gomem, error) {
+func NewGomem[T uint32 | string](processId T, desiredAccess *uint32) (*Gomem, error) {
 	var err error
 	gm := &Gomem{}
 

--- a/pkg/memory/memory.go
+++ b/pkg/memory/memory.go
@@ -16,7 +16,7 @@ type Gomem struct {
 	IsWow64       bool
 }
 
-func NewGomem[T uint32 | string](processId T, desiredAccess *uint32) (*Gomem, error) {
+func NewGomem(processId interface{}, desiredAccess *uint32) (*Gomem, error) {
 	var err error
 	gm := &Gomem{}
 

--- a/pkg/pattern/pattern.go
+++ b/pkg/pattern/pattern.go
@@ -17,18 +17,16 @@ func PatternScanModule(gm *memory.Gomem, module resources.MODULEINFO, pattern st
 	var pageAddress *uintptr = &baseAddress
 	var found []uintptr
 
-	if !returnMultiple {
-		for *pageAddress < maxAddress {
-			pageAddress, found, err = scanPatternPage(gm, *pageAddress, pattern, returnMultiple)
-			if err != nil {
-				return nil, fmt.Errorf("failed to scan page, err: %w", err)
-			}
+	for *pageAddress < maxAddress {
+		pageAddress, found, err = scanPatternPage(gm, *pageAddress, pattern, returnMultiple)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan page, err: %w", err)
+		}
 
-			if found != nil {
-				results = append(results, found...)
-				if !returnMultiple {
-					break
-				}
+		if found != nil {
+			results = append(results, found...)
+			if !returnMultiple {
+				break
 			}
 		}
 	}
@@ -50,7 +48,7 @@ func scanPatternPage(gm *memory.Gomem, address uintptr, pattern string, returnMu
 		resources.MEMORY_PROTECTION_PAGE_READONLY,
 	}
 
-	if mbi.State != uint32(resources.MEMORY_STATE_MEM_COMMIT) || slices.Contains(allowedProtections, mbi.Protect) {
+	if mbi.State != uint32(resources.MEMORY_STATE_MEM_COMMIT) || !slices.Contains(allowedProtections, mbi.Protect) {
 		return &nextRegion, nil, nil
 	}
 


### PR DESCRIPTION
`
func NewGomem(processId interface{}, desiredAccess *uint32) (*Gomem, error) {}
`
Generics cannot be asserted. This requires the use of interface types


`
func PatternScanModule(gm *memory.Gomem, module resources.MODULEINFO, pattern string, returnMultiple bool) ([]uintptr, error) {}
`
The judgment here needs to be removed. Otherwise, no memory search will be performed.
